### PR TITLE
Javascript読み込み設定

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,4 @@
 //= require jquery_ujs
 //= require jquery.turbolinks
 //= require turbolinks
-//= require_tree .
+// require_tree .

--- a/app/assets/stylesheets/modules/map.scss
+++ b/app/assets/stylesheets/modules/map.scss
@@ -1,10 +1,4 @@
-html {
-  height: 100%;
-}
-body {
-  height: 100%;
-}
 #map {
-  height: 80%;
-  width: 80%;
+  height: 500px;
+  width: 500px;
 }

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -26,7 +26,7 @@
               .head-status__user-nav
                 = form_with(model: @user, url: session_path(@user), local: true) do |f|
                   = f.text_field :username, autofocus: true, placeholder: "ユーザー名", class: "head-status__user-nav--input"
-                  = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "head-status__user-nav--input"
+                  = f.password_field :password, placeholder: "パスワード", class: "head-status__user-nav--input", autocomplete: "off"
                   = f.submit("ログイン", class: "head-status__user-nav--btn")
                   = link_to "新規登録", new_user_registration_path, class: "head-status__user-nav--btn"
     .yield-area

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -7,7 +7,6 @@
     = csp_meta_tag
     = stylesheet_link_tag    'style', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-    %script{src: ENV["GOOGLE_MAP_ADDRESS"]}
   %body
     %header.route-header
       .route-header__area

--- a/app/views/maps/index.haml
+++ b/app/views/maps/index.haml
@@ -1,1 +1,3 @@
+= javascript_include_tag 'googlemap', 'data-turbolinks-track': 'reload'
+%script{src: ENV["GOOGLE_MAP_ADDRESS"]}
 #map

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,3 +1,4 @@
+= javascript_include_tag 'user-search', 'data-turbolinks-track': 'reload'
 .new-user
   .new-user__header
     %h2 新規登録

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -27,13 +27,13 @@
         .field__label
           = f.label :password
         .field__input
-          = f.password_field :password, autocomplete: "new-password", placeholder: "入力必須(6文字以上)"
+          = f.password_field :password, autocomplete: "new-password", placeholder: "入力必須(6文字以上)", autocomplete: "off",id: "registration_password"
       .field
       .field
         .field__label
           = f.label :password_confirmation
         .field__input
-          = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "入力必須"
+          = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "入力必須", autocomplete: "off"
       .field
       .field
         = f.submit "登録する", class: "field__submit"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w( style.scss )
+Rails.application.config.assets.precompile += %w( style.scss *.js )


### PR DESCRIPTION
# WHAT
現状、全てのページで全てのJavaScriptが動作しているため、ページに合わせた物のみ動作させるようにする。
併せて既存のエラーについても対処を実施。

### JS読み込み設定変更
app/assets/javascripts/application.js
config/initializers/assets.rb
### JS共通設定読み込み
app/views/layouts/application.haml
### JS個別ファイル読み込み設定追加
app/views/maps/index.haml
app/views/users/registrations/new.html.haml
### 地図表示修正
app/assets/stylesheets/modules/map.scss

# WHY
不要なトラヒックを抑止、不要なエラーをださないようにする。
・application.jsより個別ファイル読み込み設定を解除し、precompile設定に変更。
・必要なJSは各ビューファイルから個別に呼び出す方式へ変更。
・formにてid名重複エラーが発生していた為、registrationビューにてid名変更によりエラーを回避した。
