### PR TITLE
投稿詳細ページ

### DIFF
--- a/app/assets/javascripts/googlemap.js
+++ b/app/assets/javascripts/googlemap.js
@@ -1,7 +1,7 @@
 $(function(){
   var MyLatLng = new google.maps.LatLng(34.6767339, 135.5052481);
   var Options = {
-   zoom: 15,
+   zoom: 13,
    center: MyLatLng,
    mapTypeId: 'roadmap'
   };

--- a/app/assets/stylesheets/mixin/_article.scss
+++ b/app/assets/stylesheets/mixin/_article.scss
@@ -28,6 +28,7 @@
         text-align: center;
         img {
           height: calc(#{$height / $info * ($info - 1)});
+          object-fit: contain;
         }
         .no-image {
           font-size: 20px;

--- a/app/assets/stylesheets/mixin/_article.scss
+++ b/app/assets/stylesheets/mixin/_article.scss
@@ -25,7 +25,7 @@
       &--image {
         height: calc(#{$height / $info * ($info - 1)});
         width: calc((#{$width} - #{$margin}) / #{$block});
-        // margin: 0 auto;
+        text-align: center;
         img {
           height: calc(#{$height / $info * ($info - 1)});
         }

--- a/app/assets/stylesheets/modules/map.scss
+++ b/app/assets/stylesheets/modules/map.scss
@@ -1,4 +1,4 @@
 #map {
-  height: 500px;
-  width: 500px;
+  height: 100%;
+  width: 100%;
 }

--- a/app/assets/stylesheets/modules/routes/_show.scss
+++ b/app/assets/stylesheets/modules/routes/_show.scss
@@ -1,0 +1,61 @@
+.article-detail {
+  height: 100%;
+  background: $back_color_index;
+  &__header {
+    height: 50px;
+    &--title {
+      padding-top: 10px;
+      text-align: center;
+
+    }
+  }
+  &__body {
+    height: 100%;
+    margin: 0 auto;
+    width: 1200px;
+    display: flex;
+    &--left {
+      width: 400px;
+      flex-direction: column;
+      & > div {
+        margin: 20px auto;
+        width: 80%;
+        border: 1px solid black;
+        background: #ffff80;
+        border-radius: 20px;
+      }
+      .detail-info {
+        h2 {
+          padding: 10px;
+        }
+      }
+      .detail-photo {
+        overflow: hidden;
+        h2 {
+          padding: 10px;
+        }
+        img {
+          height: 100%;
+          width: 100%;
+        }
+      }
+      .detail-map {
+        overflow: hidden;
+        height: 200px;
+      }
+    }
+    &--right {
+      width: 100%;
+      height: 100%;
+      .detail-description {
+        border-radius: 30px;
+        margin: 20px auto;
+        height: 500px;
+        width: 80%;
+        border: 1px solid black;
+        background: #ffff80;
+        overflow: auto;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/routes/_show.scss
+++ b/app/assets/stylesheets/modules/routes/_show.scss
@@ -29,16 +29,6 @@
           padding: 10px;
         }
       }
-      .detail-photo {
-        overflow: hidden;
-        h2 {
-          padding: 10px;
-        }
-        img {
-          height: 100%;
-          width: 100%;
-        }
-      }
       .detail-map {
         overflow: hidden;
         height: 200px;
@@ -47,7 +37,7 @@
     &--right {
       width: 100%;
       height: 100%;
-      .detail-description {
+      & > div {
         border-radius: 30px;
         margin: 20px auto;
         height: 500px;
@@ -55,6 +45,21 @@
         border: 1px solid black;
         background: #ffff80;
         overflow: auto;
+      }
+      .detail-photo {
+        overflow: hidden;
+        text-align:center;
+        &__photo {
+          height: 100%;
+          width: 100%;
+          img {
+            height: 100%;
+            width: 100%;
+            object-fit: contain;
+          }
+        }
+      }
+      .detail-description {
       }
     }
   }

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -19,5 +19,8 @@
 // pagination
 @import "modules/routes/pagination";
 
+// route show
+@import "modules/routes/show";
+
 // registration page
 @import "modules/registration/registration";

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -2,4 +2,7 @@ class RoutesController < ApplicationController
   def index
     @routes = Route.page(params[:page]).per(21).order("updated_at DESC")
   end
+
+  def show
+  end
 end

--- a/app/controllers/routes_controller.rb
+++ b/app/controllers/routes_controller.rb
@@ -4,5 +4,6 @@ class RoutesController < ApplicationController
   end
 
   def show
+    @route = Route.find(params[:id])
   end
 end

--- a/app/views/routes/_article.haml
+++ b/app/views/routes/_article.haml
@@ -1,5 +1,5 @@
 .article-area__box
-  = link_to "" do
+  = link_to route_path(article) do
     .article-area__box--cut
       .cut-box
         .cut-box__left

--- a/app/views/routes/show.haml
+++ b/app/views/routes/show.haml
@@ -1,0 +1,24 @@
+= javascript_include_tag 'googlemap', 'data-turbolinks-track': 'reload'
+%script{src: ENV["GOOGLE_MAP_ADDRESS"]}
+.article-detail
+  .article-detail__header
+    .article-detail__header--title
+      %h1 title
+  .article-detail__body
+    .article-detail__body--left
+      .detail-info
+        %h2
+          UserName:
+          = @route.user.username
+      .detail-photo
+        - if @route.route_photos.length > 0
+          .detail-photo__photo
+            = image_tag(@route.route_photos.first.photo)
+        - else
+          .detail-photo__no-photo
+            no_image
+      .detail-map
+        #map
+    .article-detail__body--right
+      .detail-description
+        = @route.description

--- a/app/views/routes/show.haml
+++ b/app/views/routes/show.haml
@@ -7,9 +7,16 @@
   .article-detail__body
     .article-detail__body--left
       .detail-info
-        %h2
+        %h2 UserInfo
+        .span
           UserName:
           = @route.user.username
+        - for num in 1..10 do
+          .span
+            データ
+      .detail-map
+        #map
+    .article-detail__body--right
       .detail-photo
         - if @route.route_photos.length > 0
           .detail-photo__photo
@@ -17,8 +24,7 @@
         - else
           .detail-photo__no-photo
             no_image
-      .detail-map
-        #map
-    .article-detail__body--right
       .detail-description
         = @route.description
+      .detail-route
+        ルート表示

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   root 'routes#index'
   resources :maps, only: [:index]
-  resources :routes, only: [:index]
+  resources :routes, only: [:index, :show]
   resources :users do
     collection do
       get "search"


### PR DESCRIPTION
# WHAT
投稿の詳細ページを作成し、現状作成モデルに対して、具体的な内容が表示されるようにする。
### ルーティング追加
config/routes.rb
### コントローラ、アクション追加とDBよりデータ取得
app/controllers/routes_controller.rb

### 記事詳細ビュー追加
app/views/routes/show.haml
### 記事一覧より詳細ページへのリンクを追加
app/assets/stylesheets/mixin/_article.scss
### 記事一覧部分テンプレート設定変更（中央表示）
app/views/routes/_article.haml
### 記事詳細ページスタイルシート作成とインポート
app/assets/stylesheets/modules/routes/_show.scss
app/assets/stylesheets/style.scss
### マップ表示エリア、サイズ修正
app/assets/stylesheets/modules/map.scss
### マップ表示、ズーム値修正
app/assets/javascripts/googlemap.js

# WHY
記事の詳細画面ベースを作成し、既存モデルの情報を反映。
・画面左側にユーザの情報及び記事詳細の対象エリア表示をする為の地図を表示。（現在はデフォルト位置のマップが固定で表示されている）
・画面右側に、上から写真・記事・ルート情報をだす為のエリアを作成。現状は写真1枚のみ・記事情報が表示される状態としている。
・写真について、縦横比保持の為に設定、object-fit: contain;を追加あわせてトップページにも対応した。